### PR TITLE
Added debug mode to all resources.

### DIFF
--- a/filters/pom.xml
+++ b/filters/pom.xml
@@ -69,6 +69,11 @@
             <artifactId>json</artifactId>
             <version>20170516</version>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+        </dependency>
 
         <!-- JETTY -->
         <dependency>
@@ -109,6 +114,12 @@
             <groupId>net.sf.okapi</groupId>
             <artifactId>okapi-core</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- OKAPI STEPS -->
@@ -116,26 +127,60 @@
             <groupId>net.sf.okapi.steps</groupId>
             <artifactId>okapi-step-common</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.steps</groupId>
             <artifactId>okapi-step-whitespacecorrection</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.steps</groupId>
             <artifactId>okapi-step-segmentation</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.steps</groupId>
             <artifactId>okapi-step-encodingconversion</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.steps</groupId>
             <artifactId>okapi-step-rainbowkit</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>junit</artifactId>
+                    <groupId>junit</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- OKAPI FILTERS -->
@@ -143,121 +188,265 @@
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-rainbowkit</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-html</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-plaintext</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-openxml</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-openoffice</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-php</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-its</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-properties</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-po</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-xliff</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-json</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-idml</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-icml</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-txml</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-yaml</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-mif</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-xmlstream</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-table</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-archive</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-xini</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-regex</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-ttx</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-ts</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.sf.okapi.filters</groupId>
             <artifactId>okapi-filter-dtd</artifactId>
             <version>${okapi.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/filters/src/main/java/com/matecat/converter/server/resources/ExtractOriginalFileResource.java
+++ b/filters/src/main/java/com/matecat/converter/server/resources/ExtractOriginalFileResource.java
@@ -4,20 +4,17 @@ import com.matecat.converter.core.XliffProcessor;
 import com.matecat.converter.core.project.Project;
 import com.matecat.converter.core.project.ProjectFactory;
 import com.matecat.converter.server.JSONResponseFactory;
+import com.matecat.logging.StoringAppender;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-
 
 /**
  * Resource taking care of the extraction of the original file from the .XLF
@@ -25,9 +22,8 @@ import java.io.InputStream;
 @Path("/AutomationService/xliff2source")
 public class ExtractOriginalFileResource {
 
-    // Logger
-    private static final Logger LOGGER = LoggerFactory.getLogger(ExtractOriginalFileResource.class);
-
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConvertToXliffResource.class);
+    private static final StoringAppender LOG_CAPTURER = new StoringAppender();
 
     /**
      * Extract the original file from the xlf
@@ -35,56 +31,68 @@ public class ExtractOriginalFileResource {
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces("application/json")
-    public Response convert(@FormDataParam("file") InputStream fileInputStream) {
+    public Response convert(
+            @FormDataParam("file") InputStream fileInputStream,
+            @FormDataParam("debugMode") @DefaultValue("false") boolean debugMode) {
+        // If debug mode requested install the log capturer
+        if (debugMode) {
+            LOG_CAPTURER.install();
+        }
 
-        // Logging
         LOGGER.info("XLIFF > SOURCE request");
 
         Project project = null;
+        File originalFile = new File("");
+        String errorMessage = "Unknown error";
         Response response;
         boolean everythingOk = false;
         try {
-
             // Check that the input file is not null
-            if (fileInputStream == null)
+            if (fileInputStream == null) {
                 throw new IllegalArgumentException("The input file has not been sent");
+            }
 
             // Create the project
             project = ProjectFactory.createProject("to-original.xlf", fileInputStream);
 
             // Retrieve the xlf
-            File originalFile = new XliffProcessor(project.getFile()).getOriginalFile();
+            originalFile = new XliffProcessor(project.getFile()).getOriginalFile();
 
-            // Create response
-            response = Response
-                    .status(Response.Status.OK)
-                    .entity(JSONResponseFactory.getDerivedSuccess(originalFile))
-                    .build();
-
+            // Set OK flag
             everythingOk = true;
             LOGGER.info("Successfully returned source file");
-        }
-
-        // If there is any error, return it
-        catch (Exception e) {
-            response = Response
-                    .status(Response.Status.BAD_REQUEST)
-                    .entity(JSONResponseFactory.getError(e.getMessage()))
-                    .build();
-            LOGGER.error("Exception extracting source file from XLIFF", e);
-        }
-
-        // Close the project and streams
-        finally {
+        } catch (Exception e) {
+            // Save error message
+            errorMessage = e.toString();
+            LOGGER.error("Exception converting XLIFF to source", e);
+        } finally {
+            // Create response
+            if (everythingOk) {
+                response = Response
+                        .status(Response.Status.OK)
+                        .entity(JSONResponseFactory.getDerivedSuccess(originalFile, LOG_CAPTURER.getStoredLog()))
+                        .build();
+            } else {
+                response = Response
+                        .status(Response.Status.BAD_REQUEST)
+                        .entity(JSONResponseFactory.getError(errorMessage, LOG_CAPTURER.getStoredLog()))
+                        .build();
+            }
+            // Close the project and streams
             if (fileInputStream != null)
                 try {
                     fileInputStream.close();
-                } catch (IOException ignored) {}
+                } catch (IOException ignored) {
+                }
             if (project != null)
                 // Delete folder only if everything went well
                 project.close(everythingOk);
+            // If debug mode requested de-install the log capturer
+            if (debugMode) {
+                LOG_CAPTURER.clear();
+                LOG_CAPTURER.deinstall();
+            }
         }
-
         return response;
     }
 

--- a/filters/src/main/java/com/matecat/converter/server/resources/GenerateDerivedFileResource.java
+++ b/filters/src/main/java/com/matecat/converter/server/resources/GenerateDerivedFileResource.java
@@ -4,20 +4,17 @@ import com.matecat.converter.core.project.Project;
 import com.matecat.converter.core.project.ProjectFactory;
 import com.matecat.converter.server.JSONResponseFactory;
 import com.matecat.filters.basefilters.FiltersRouter;
+import com.matecat.logging.StoringAppender;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-
 
 /**
  * Resource taking care of the generation of the new file from the .XLF
@@ -25,8 +22,8 @@ import java.io.InputStream;
 @Path("/AutomationService/xliff2original")
 public class GenerateDerivedFileResource {
 
-    // Logger
-    private static final Logger LOGGER = LoggerFactory.getLogger(GenerateDerivedFileResource.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConvertToXliffResource.class);
+    private static final StoringAppender LOG_CAPTURER = new StoringAppender();
 
     /**
      * Generate the derived file from the xlf
@@ -35,16 +32,21 @@ public class GenerateDerivedFileResource {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces("application/json")
     public Response convert(
-            @FormDataParam("xliffContent") InputStream fileInputStream) {
+            @FormDataParam("xliffContent") InputStream fileInputStream,
+            @FormDataParam("debugMode") @DefaultValue("false") boolean debugMode) {
+        // If debug mode requested install the log capturer
+        if (debugMode) {
+            LOG_CAPTURER.install();
+        }
 
-        // Logging
         LOGGER.info("XLIFF > TARGET request");
 
         Project project = null;
+        File derivedFile = new File("");
+        String errorMessage = "Unknown error";
         Response response;
         boolean everythingOk = false;
         try {
-
             // Check that the input file is not null
             if (fileInputStream == null)
                 throw new IllegalArgumentException("The input file has not been sent");
@@ -53,40 +55,43 @@ public class GenerateDerivedFileResource {
             project = ProjectFactory.createProject("to-derived.xlf", fileInputStream);
 
             // Retrieve the xlf
-            File derivedFile = new FiltersRouter().merge(project.getFile());
-
-            // Create response
-            response = Response
-                    .status(Response.Status.OK)
-                    .entity(JSONResponseFactory.getDerivedSuccess(derivedFile))
-                    .build();
+            derivedFile = new FiltersRouter().merge(project.getFile());
 
             everythingOk = true;
             LOGGER.info("Successfully returned target file");
-        }
-
-        // If there is any error, return it
-        catch (Exception e) {
-            response = Response
-                    .status(Response.Status.BAD_REQUEST)
-                    .entity(JSONResponseFactory.getError(e.getMessage()))
-                    .build();
+        } catch (Exception e) {
+            // save error message
+            errorMessage = e.toString();
             LOGGER.error("Exception converting XLIFF to target", e);
-        }
-
-        // Close the project and streams
-        finally {
+        } finally {
+            // Create response
+            if (everythingOk) {
+                response = Response
+                        .status(Response.Status.OK)
+                        .entity(JSONResponseFactory.getDerivedSuccess(derivedFile, LOG_CAPTURER.getStoredLog()))
+                        .build();
+            } else {
+                response = Response
+                        .status(Response.Status.BAD_REQUEST)
+                        .entity(JSONResponseFactory.getError(errorMessage, LOG_CAPTURER.getStoredLog()))
+                        .build();
+            }
+            // Close the project and streams
             if (fileInputStream != null)
                 try {
                     fileInputStream.close();
-                } catch (IOException ignored) {}
+                } catch (IOException ignored) {
+                }
             if (project != null)
                 // Delete folder only if everything went well
                 project.close(everythingOk);
+            // If debug mode requested de-install the log capturer
+            if (debugMode) {
+                LOG_CAPTURER.clear();
+                LOG_CAPTURER.deinstall();
+            }
         }
-
         return response;
-
     }
 
 }

--- a/filters/src/main/java/com/matecat/logging/StoringAppender.java
+++ b/filters/src/main/java/com/matecat/logging/StoringAppender.java
@@ -1,0 +1,104 @@
+package com.matecat.logging;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.AppenderBase;
+import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.encoder.Encoder;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
+
+/**
+ * A Logback appender that intercepts and stores all the log events.
+ * <p/>
+ * The appender is meant to be temporarily installed to the root logger and reuses
+ * the encoder of the first {@link ConsoleAppender} it finds or install its own.
+ * The stored events can afterwards be retrieved as a String.
+ * <p/>
+ * <b>NOTE:</b> if not deinstalled it may exhaust all the memory by storing all
+ * the log events indefinitely.
+ */
+public class StoringAppender extends AppenderBase<ILoggingEvent> {
+    public static final String APPENDER_NAME = "interceptor";
+    public static final String DEFAULT_PATTERN = "%d{HH:mm:ss.SSS} %-5level %logger{30} - %msg%n";
+    private final Queue<ILoggingEvent> loggingEvents = new ConcurrentLinkedQueue<>();
+    private Encoder<ILoggingEvent> encoder;
+
+    public StoringAppender() {
+        setName(APPENDER_NAME);
+    }
+
+    // this method is not called if the appender is not started
+    // start happens in the install method
+    @Override
+    protected void append(ILoggingEvent iLoggingEvent) {
+        loggingEvents.add(iLoggingEvent);
+    }
+
+    /**
+     * Clears the stored log events.
+     */
+    public void clear() {
+        loggingEvents.clear();
+    }
+
+    /**
+     * Retrieves the stored log events.
+     *
+     * @return an array of {@code String}s with all the encoded log events
+     */
+    public synchronized List<String> getStoredLog() {
+        return loggingEvents.stream()
+                .map(iLoggingEvent -> new String(encoder.encode(iLoggingEvent), StandardCharsets.UTF_8))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Installs this appender into the Logback root logger.
+     */
+    public synchronized void install() {
+        LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+        this.setContext(lc);
+        final Logger rootLogger = lc.getLogger(Logger.ROOT_LOGGER_NAME);
+        // look for a ConsoleAppender and "steal" its encoder
+        boolean consoleFound = false;
+        final Iterator<Appender<ILoggingEvent>> it = rootLogger.iteratorForAppenders();
+        while (it.hasNext()) {
+            Appender<ILoggingEvent> appender = it.next();
+            if (appender instanceof ConsoleAppender) {
+                final ConsoleAppender<ILoggingEvent> ca = (ConsoleAppender<ILoggingEvent>) appender;
+                this.encoder = ca.getEncoder();
+                consoleFound = true;
+                break;
+            }
+        }
+        // if no ConsoleAppender found define our own encoder
+        if (!consoleFound) {
+            final PatternLayoutEncoder ple = new PatternLayoutEncoder();
+            ple.setPattern(DEFAULT_PATTERN);
+            this.encoder = ple;
+        }
+        // start our self and add to root logger
+        this.start();
+        rootLogger.addAppender(this);
+    }
+
+    /**
+     * De-installs the appender from the Logback root logger.
+     */
+    public synchronized void deinstall() {
+        this.stop();
+        LoggerContext lc = (LoggerContext) getContext();
+        final Logger rootLogger = lc.getLogger(Logger.ROOT_LOGGER_NAME);
+        rootLogger.detachAppender(APPENDER_NAME);
+    }
+}

--- a/filters/src/main/resources/client/client.html
+++ b/filters/src/main/resources/client/client.html
@@ -6,147 +6,209 @@
 	<title>MateCat Filters {{filtersVersion}}</title>
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
 	<style>
-
 		/* RESET */
-		html,body,div,span,applet,object,iframe,h1,h2,h3,h4,h5,h6,p,blockquote,pre,a,abbr,acronym,address,big,cite,code,del,dfn,em,img,ins,kbd,q,s,samp,small,strike,strong,sub,sup,tt,var,b,u,i,center,dl,dt,dd,ol,ul,li,fieldset,form,label,legend,table,caption,tbody,tfoot,thead,tr,th,td,article,aside,canvas,details,embed,figure,figcaption,footer,header,hgroup,menu,nav,output,ruby,section,summary,time,mark,audio,video{margin:0;padding:0;border:0;font-size:100%;font:inherit;vertical-align:baseline}article,aside,details,figcaption,figure,footer,header,hgroup,menu,nav,section{display:block}body{line-height:1}ol,ul{list-style:none}blockquote,q{quotes:none}blockquote:before,blockquote:after,q:before,q:after{content:'';content:none}table{border-collapse:collapse;border-spacing:0}
+        html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video {
+            margin: 0;
+            padding: 0;
+            border: 0;
+            font-size: 100%;
+            font: inherit;
+            vertical-align: baseline
+        }
 
-		* { box-sizing: border-box; }
-		input, textarea {
-		-webkit-appearance: none;
-		-webkit-border-radius: 0;
-		}
-		input:focus, textarea:focus {
-		outline:none;
-		}
-		input[type=file]::-webkit-file-upload-button {
-		visibility: hidden;
-		}
+        article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section {
+            display: block
+        }
 
-		/* COMMON */
-		body {
-		font-family: Calibri, Arial, Helvetica, sans-serif;
-		}
-		strong { font-weight: bold; }
-		.icon {
-		cursor: pointer;
-		position: relative;
-		top: 5px;
-		}
-		input[type=button] {
-		background-color: rgb(0, 176, 218);
-		padding: 12px 20px;
-		font-size: 1em;
-		border: 1px solid #00b0da;
-		cursor: pointer;
-		color: white;
-		border-radius: 5px;
-		margin: 2px 0 2px 10px;
-		width: 175px;
-		}
-		input:disabled {
-		background-color: gainsboro;
-		border-color: gainsboro;
-		}
-		header {
-		width: 100%;
-		color: white;
-		text-align: center;
-		padding: 20px 0;
-		background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIGNvdW50PScxMDAlJyBoZWlnaHQ9JzEwMCUnPgoJPGNpcmNsZSBjeD0nNTAlJyBjeT0nNTAlJyByPSc1JScgZmlsbC1vcGFjaXR5PScuMycgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9JzUwJScgcj0nMTAlJyBmaWxsLW9wYWNpdHk9Jy4zJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nNTAlJyBjeT0nNTAlJyByPScxNSUnIGZpbGwtb3BhY2l0eT0nLjMnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PSc1MCUnIGN5PSc1MCUnIHI9JzIwJScgZmlsbC1vcGFjaXR5PScuMycgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9JzUwJScgcj0nMjUlJyBmaWxsLW9wYWNpdHk9Jy4zJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nNTAlJyBjeT0nNTAlJyByPSczMCUnIGZpbGwtb3BhY2l0eT0nLjMnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PSc1MCUnIGN5PSc1MCUnIHI9JzM1JScgZmlsbC1vcGFjaXR5PScuMycgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9JzUwJScgcj0nNDAlJyBmaWxsLW9wYWNpdHk9Jy4zJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nNTAlJyBjeT0nNTAlJyByPSc0NSUnIGZpbGwtb3BhY2l0eT0nLjMnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PSc1MCUnIGN5PSc1MCUnIHI9JzUwJScgZmlsbC1vcGFjaXR5PScuMycgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzIwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzMwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzQwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzUwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzYwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzcwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzgwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzkwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzEwMCUnIGZpbGwtb3BhY2l0eT0nLjInIGZpbGw9JyMxZjdlYWQnIC8+Cgk8Y2lyY2xlIGN4PScwJyBjeT0nMCcgcj0nMTAlJyBmaWxsLW9wYWNpdHk9Jy4yJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nMCcgY3k9JzAnIHI9JzIwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzAnIGN5PScwJyByPSczMCUnIGZpbGwtb3BhY2l0eT0nLjInIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PScwJyBjeT0nMCcgcj0nNDAlJyBmaWxsLW9wYWNpdHk9Jy4yJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nMCcgY3k9JzAnIHI9JzUwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzAnIGN5PScwJyByPSc2MCUnIGZpbGwtb3BhY2l0eT0nLjInIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PScwJyBjeT0nMCcgcj0nNzAlJyBmaWxsLW9wYWNpdHk9Jy4yJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nMTAwJScgY3k9JzAnIHI9JzEwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzEwMCUnIGN5PScwJyByPScyMCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMxZjdlYWQnIC8+Cgk8Y2lyY2xlIGN4PScxMDAlJyBjeT0nMCcgcj0nMzAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMWY3ZWFkJyAvPgoJPGNpcmNsZSBjeD0nMTAwJScgY3k9JzAnIHI9JzQwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzEwMCUnIGN5PScwJyByPSc1MCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMxZjdlYWQnIC8+Cgk8Y2lyY2xlIGN4PScxMDAlJyBjeT0nMCcgcj0nNjAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMWY3ZWFkJyAvPgoJPGNpcmNsZSBjeD0nMTAwJScgY3k9JzAnIHI9JzcwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzEwMCUnIGN5PScxMDAlJyByPScxMCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PScxMDAlJyBjeT0nMTAwJScgcj0nMjAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nMTAwJScgY3k9JzEwMCUnIHI9JzMwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzEwMCUnIGN5PScxMDAlJyByPSc0MCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PScxMDAlJyBjeT0nMTAwJScgcj0nNTAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nMTAwJScgY3k9JzEwMCUnIHI9JzYwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzEwMCUnIGN5PScxMDAlJyByPSc3MCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PScwJScgY3k9JzEwMCUnIHI9JzEwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzAlJyBjeT0nMTAwJScgcj0nMjAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMWY3ZWFkJyAvPgoJPGNpcmNsZSBjeD0nMCUnIGN5PScxMDAlJyByPSczMCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMxZjdlYWQnIC8+Cgk8Y2lyY2xlIGN4PScwJScgY3k9JzEwMCUnIHI9JzQwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzAlJyBjeT0nMTAwJScgcj0nNTAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMWY3ZWFkJyAvPgoJPGNpcmNsZSBjeD0nMCUnIGN5PScxMDAlJyByPSc2MCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMxZjdlYWQnIC8+Cgk8Y2lyY2xlIGN4PScwJScgY3k9JzEwMCUnIHI9JzcwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KPC9zdmc+');
-		}
+        body {
+            line-height: 1
+        }
 
-		/* ERROR MESAGE */
-		#error {
-		padding: 20px 20px;
-		width: 100%;
-		text-align: center;
-		position: fixed;
-		color: #D8000C;
-		background-color: #FFBABA;
-		bottom: 0;
-		-webkit-transition: opacity .5s ease-in-out;
-		transition: opacity .5s ease-in-out;
-		opacity: 0;
-		filter: alpha(opacity=0);
-		}
+        ol, ul {
+            list-style: none
+        }
 
-		/* HEADERS */
-		h1, h2 { font-weight: bold; }
-		h1 { font-size: 3em; }
-		h2 { font-size: 2em; margin-bottom: 0.5em; }
+        blockquote, q {
+            quotes: none
+        }
 
-		/* SECTIONS */
-		section {
-		text-align: center;
-		padding: 20px 0 10px;
-		}
-		#section-upload, #section-process {
-		-webkit-transition: opacity .5s ease-in-out;
-		transition: opacity .5s ease-in-out;
-		opacity: 0;
-		filter: alpha(opacity=0);
-		}
+        blockquote:before, blockquote:after, q:before, q:after {
+            content: '';
+            content: none
+        }
 
-		/* OPTIONS */
-		#options li {
-		display: inline-block;
-		text-align: center;
-		margin: 0 20px;
-		padding: 10px;
-		border-radius: 10px;
-		cursor: pointer;
-		}
-		#options i {
-		margin-bottom: 10px;
-		}
-		.option-selected {
-		background-color: #00b0da;
-		color: white;
-		}
+        table {
+            border-collapse: collapse;
+            border-spacing: 0
+        }
 
-		/* FILE */
-		#file { display: none; }
-		#file-details {
-		-webkit-transition: opacity .5s ease-in-out;
-		transition: opacity .5s ease-in-out;
-		opacity: 0;
-		filter: alpha(opacity=0);
-		margin-top: 10px;
-		}
-		#img-loading {
-		display: none;
-		width: 30px;
-		height: 30px;
-		position: relative;
-		top: 10px;
-		margin-right: -2px;
-		}
-		#icon-process {
-		margin-right: -2px;
-		left: 3px;
-		}
+        /* COMMON */
+        * {
+            box-sizing: border-box;
+        }
 
-		/* Process */
-		#section-process div { margin-bottom: 10px; }
+        input[type=file]::-webkit-file-upload-button {
+            visibility: hidden;
+        }
 
-	</style>
+        body {
+            font-family: Calibri, Arial, Helvetica, sans-serif;
+        }
+
+        strong {
+            font-weight: bold;
+        }
+
+        .icon {
+            cursor: pointer;
+            position: relative;
+            top: 5px;
+        }
+
+        input[type=button] {
+            background-color: rgb(0, 176, 218);
+            padding: 12px 20px;
+            font-size: 1em;
+            border: 1px solid #00b0da;
+            cursor: pointer;
+            color: white;
+            border-radius: 5px;
+            margin: 2px 0 2px 10px;
+            width: 175px;
+        }
+
+        input:disabled {
+            background-color: gainsboro;
+            border-color: gainsboro;
+        }
+
+        header {
+            width: 100%;
+            color: white;
+            text-align: center;
+            padding: 20px 0;
+            background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIGNvdW50PScxMDAlJyBoZWlnaHQ9JzEwMCUnPgoJPGNpcmNsZSBjeD0nNTAlJyBjeT0nNTAlJyByPSc1JScgZmlsbC1vcGFjaXR5PScuMycgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9JzUwJScgcj0nMTAlJyBmaWxsLW9wYWNpdHk9Jy4zJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nNTAlJyBjeT0nNTAlJyByPScxNSUnIGZpbGwtb3BhY2l0eT0nLjMnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PSc1MCUnIGN5PSc1MCUnIHI9JzIwJScgZmlsbC1vcGFjaXR5PScuMycgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9JzUwJScgcj0nMjUlJyBmaWxsLW9wYWNpdHk9Jy4zJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nNTAlJyBjeT0nNTAlJyByPSczMCUnIGZpbGwtb3BhY2l0eT0nLjMnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PSc1MCUnIGN5PSc1MCUnIHI9JzM1JScgZmlsbC1vcGFjaXR5PScuMycgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9JzUwJScgcj0nNDAlJyBmaWxsLW9wYWNpdHk9Jy4zJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nNTAlJyBjeT0nNTAlJyByPSc0NSUnIGZpbGwtb3BhY2l0eT0nLjMnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PSc1MCUnIGN5PSc1MCUnIHI9JzUwJScgZmlsbC1vcGFjaXR5PScuMycgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzIwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzMwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzQwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzUwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzYwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzcwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzgwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzkwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzUwJScgY3k9Jy0xMCUnIHI9JzEwMCUnIGZpbGwtb3BhY2l0eT0nLjInIGZpbGw9JyMxZjdlYWQnIC8+Cgk8Y2lyY2xlIGN4PScwJyBjeT0nMCcgcj0nMTAlJyBmaWxsLW9wYWNpdHk9Jy4yJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nMCcgY3k9JzAnIHI9JzIwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzAnIGN5PScwJyByPSczMCUnIGZpbGwtb3BhY2l0eT0nLjInIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PScwJyBjeT0nMCcgcj0nNDAlJyBmaWxsLW9wYWNpdHk9Jy4yJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nMCcgY3k9JzAnIHI9JzUwJScgZmlsbC1vcGFjaXR5PScuMicgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzAnIGN5PScwJyByPSc2MCUnIGZpbGwtb3BhY2l0eT0nLjInIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PScwJyBjeT0nMCcgcj0nNzAlJyBmaWxsLW9wYWNpdHk9Jy4yJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nMTAwJScgY3k9JzAnIHI9JzEwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzEwMCUnIGN5PScwJyByPScyMCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMxZjdlYWQnIC8+Cgk8Y2lyY2xlIGN4PScxMDAlJyBjeT0nMCcgcj0nMzAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMWY3ZWFkJyAvPgoJPGNpcmNsZSBjeD0nMTAwJScgY3k9JzAnIHI9JzQwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzEwMCUnIGN5PScwJyByPSc1MCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMxZjdlYWQnIC8+Cgk8Y2lyY2xlIGN4PScxMDAlJyBjeT0nMCcgcj0nNjAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMWY3ZWFkJyAvPgoJPGNpcmNsZSBjeD0nMTAwJScgY3k9JzAnIHI9JzcwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzEwMCUnIGN5PScxMDAlJyByPScxMCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PScxMDAlJyBjeT0nMTAwJScgcj0nMjAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nMTAwJScgY3k9JzEwMCUnIHI9JzMwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzEwMCUnIGN5PScxMDAlJyByPSc0MCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PScxMDAlJyBjeT0nMTAwJScgcj0nNTAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMjRiZGViJyAvPgoJPGNpcmNsZSBjeD0nMTAwJScgY3k9JzEwMCUnIHI9JzYwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzI0YmRlYicgLz4KCTxjaXJjbGUgY3g9JzEwMCUnIGN5PScxMDAlJyByPSc3MCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMyNGJkZWInIC8+Cgk8Y2lyY2xlIGN4PScwJScgY3k9JzEwMCUnIHI9JzEwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzAlJyBjeT0nMTAwJScgcj0nMjAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMWY3ZWFkJyAvPgoJPGNpcmNsZSBjeD0nMCUnIGN5PScxMDAlJyByPSczMCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMxZjdlYWQnIC8+Cgk8Y2lyY2xlIGN4PScwJScgY3k9JzEwMCUnIHI9JzQwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KCTxjaXJjbGUgY3g9JzAlJyBjeT0nMTAwJScgcj0nNTAlJyBmaWxsLW9wYWNpdHk9Jy4xJyBmaWxsPScjMWY3ZWFkJyAvPgoJPGNpcmNsZSBjeD0nMCUnIGN5PScxMDAlJyByPSc2MCUnIGZpbGwtb3BhY2l0eT0nLjEnIGZpbGw9JyMxZjdlYWQnIC8+Cgk8Y2lyY2xlIGN4PScwJScgY3k9JzEwMCUnIHI9JzcwJScgZmlsbC1vcGFjaXR5PScuMScgZmlsbD0nIzFmN2VhZCcgLz4KPC9zdmc+');
+        }
+
+        /* ERROR MESAGE */
+        #error {
+            display: none;
+            padding: 20px 20px;
+            width: 100%;
+            text-align: center;
+            color: #D8000C;
+            background-color: #FFBABA;
+        }
+
+        /* HEADERS */
+        h1, h2 {
+            font-weight: bold;
+        }
+
+        h1 {
+            font-size: 3em;
+        }
+
+        h2 {
+            font-size: 2em;
+            margin-bottom: 0.5em;
+        }
+
+        /* SECTIONS */
+        section {
+            text-align: center;
+            padding: 20px 0 10px;
+        }
+
+        #section-upload, #section-process {
+            -webkit-transition: opacity .5s ease-in-out;
+            transition: opacity .5s ease-in-out;
+            opacity: 0;
+            filter: alpha(opacity=0);
+        }
+
+        #section-log {
+            text-align: left;
+            -webkit-transition: opacity .5s ease-in-out;
+            transition: opacity .5s ease-in-out;
+            opacity: 0;
+            filter: alpha(opacity=0);
+        }
+
+        /* OPTIONS */
+        #options li {
+            display: inline-block;
+            text-align: center;
+            margin: 0 20px;
+            padding: 10px;
+            border-radius: 10px;
+            cursor: pointer;
+        }
+
+        #options i {
+            margin-bottom: 10px;
+        }
+
+        .option-selected {
+            background-color: #00b0da;
+            color: white;
+        }
+
+        /* FILE */
+        #file {
+            display: none;
+        }
+
+        #file-details {
+            -webkit-transition: opacity .5s ease-in-out;
+            transition: opacity .5s ease-in-out;
+            opacity: 0;
+            filter: alpha(opacity=0);
+            margin-top: 10px;
+        }
+
+        #img-loading {
+            display: none;
+            width: 30px;
+            height: 30px;
+            position: relative;
+            top: 10px;
+            margin-right: -2px;
+        }
+
+        #icon-process {
+            margin-right: -2px;
+            left: 3px;
+        }
+
+        /* Process */
+        #section-process div {
+            margin-bottom: 10px;
+        }
+
+        /* Logs */
+        #loglines {
+            width: 100%;
+            height: auto;
+        }
+    </style>
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 	<script src="//oss.maxcdn.com/jquery.form/3.50/jquery.form.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2014-11-29/FileSaver.min.js"></script>
 	<script>
-        
+
         // Constants
         var CONVERT = 'convert', ORIGINAL = 'original', DERIVED = 'derived';
-        
+
         // Status
         var option = '';
         var filenameUploaded = '';
         var fileToDownload = null;
         var filenameToDownload = '';
-        
+
         // Visual
         $(function() {
-            
+
             // Change option
             $('#option-generate').click(function() {
                 option = CONVERT;
@@ -160,7 +222,7 @@
                 option = DERIVED;
                 changeOption(this, 'Get the translation!');
             });
-            
+
             // Upload a file
             $('#icon-upload').click(function() {
                 $('#file').click();
@@ -181,7 +243,7 @@
                     $('#button-download').attr('disabled','disabled');
                 }, 500);
             });
-            
+
             // Process
             $('#icon-process').click(function() {
                 process();
@@ -189,7 +251,7 @@
             $('#button-process').click(function() {
                 process();
             });
-            
+
             // Download
             $('#icon-download').click(function() {
                 download();
@@ -197,9 +259,9 @@
             $('#button-download').click(function() {
                 download();
             });
-        
+
         });
-        
+
         // Process
         function process() {
             /*if (option != CONVERT  &&  filenameUploaded.split('.').pop() != 'xlf') {
@@ -209,9 +271,15 @@
                 console.log("Executing: " + option);
                 var url = '';
                 switch (option) {
-                    case CONVERT  : url = 'AutomationService/original2xliff'; break;
-                    case ORIGINAL : url = '/AutomationService/xliff2source'; break;
-                    case DERIVED  : url = 'AutomationService/xliff2original'; break;
+                    case CONVERT  :
+                        url = '/AutomationService/original2xliff';
+                        break;
+                    case ORIGINAL :
+                        url = '/AutomationService/xliff2source';
+                        break;
+                    case DERIVED  :
+                        url = '/AutomationService/xliff2original';
+                        break;
                 }
                 console.log("URL: " + url);
                 $('#form-file').ajaxSubmit({
@@ -222,25 +290,28 @@
                 });
             //}
         }
-        
+
         // Download
         function download() {
             if (fileToDownload != null)
                     saveAs(fileToDownload, filenameToDownload);
         }
-        
+
         // Change an option
         function changeOption(selected, processMessage) {
             var fileInputName;
             switch (option) {
                 case CONVERT:
                     fileInputName = "documentContent";
+                    $('.locale').css('display', 'block')
                     break;
                 case ORIGINAL:
                     fileInputName = "file";
+                    $('.locale').css('display', 'none')
                     break;
                 case DERIVED:
                     fileInputName = "xliffContent";
+                    $('.locale').css('display', 'none')
                     break;
             }
             $('#options li').removeClass('option-selected');
@@ -249,14 +320,15 @@
             $('#file').prop('name', fileInputName).val('');
             $('#file-details').css('opacity', 0);
             $('#file-details').val('');
-            $('#section-process').css('opacity',0);
-            setTimeout(function() {
-                    $('#button-process').val(processMessage);
-                    $('#button-process').attr('disabled','disabled');
-                    $('#button-download').attr('disabled','disabled');
-                }, 1000);
+            $('#section-process').css('opacity', 0);
+            $('#section-log').css('opacity', 0);
+            setTimeout(function () {
+                $('#button-process').val(processMessage);
+                $('#button-process').attr('disabled', 'disabled');
+                $('#button-download').attr('disabled', 'disabled');
+            }, 1000);
         }
-        
+
         // Pre processing
         function preProcess() {
             $('#button-download').attr('disabled','disabled');
@@ -265,42 +337,46 @@
             $('#img-loading').css('display','inline-block');
             $('#img-loading').css('opacity', 1);
         }
-        
+
         // Sucess in processing
         function processSuccess(response) {
             if (response.documentContent) {
                 fileToDownload = b64toBlob(response.documentContent);
             } else {
-                fileToDownload = new Blob([response.xliffContent], {type : 'text/xml'});
+                fileToDownload = new Blob([response.xliffContent], {type: 'text/xml'});
             }
             filenameToDownload = response.filename;
+            if (response.log) {
+                $('#section-log').css('opacity', 1);
+                $('#loglines').text(response.log.join(''));
+            }
             $('#button-download').removeAttr('disabled');
             $('#button-process').removeAttr('disabled');
-            $('#icon-process').css('display','inline-block');
-            $('#img-loading').css('display','none');
+            $('#icon-process').css('display', 'inline-block');
+            $('#img-loading').css('display', 'none');
+            $('#error').css('display', 'none');
         }
 
         // Error in processing
         function processError(response) {
             $('#button-process').removeAttr('disabled');
-            $('#icon-process').css('display','inline-block');
-            $('#img-loading').css('display','none');
-            console.log(JSON.parse(response.responseText));
-            showError(JSON.parse(response.responseText).errorMessage);
+            $('#icon-process').css('display', 'inline-block');
+            $('#img-loading').css('display', 'none');
+            $('#section-log').css('opacity', 1);
+            console.log('Error: ' + response.statusText)
+            showError(response.responseJSON.errorMessage);
+            if (response.responseJSON.log) {
+                $('#loglines').text(response.responseJSON.log.join(''));
+            } else {
+                $('#loglines').text('No log retrieved');
+            }
         }
-        
+
         // Show an error
         function showError(message) {
             $('#error')
-                .html(message)
-                .css('visibility','visible')
-                .css('opacity',1);
-            setTimeout(function() {
-                $('#error').css('opacity', 0);
-                setTimeout(function() {
-                    $('#error').css('visibility','hidden');
-                }, 1000);
-            }, 2000);
+                    .html(message)
+                    .css('display', 'block');
         }
 
         // Generate blob from base 64
@@ -323,13 +399,10 @@
             });
             return blob;
         }
-    
+
     </script>
 </head>
 <body>
-<div id="error">
-	This is an error message!
-</div>
 <header><h1>Matecat Filters {{filtersVersion}}</h1></header>
 <section id="section-option">
 	<h2>1. Choose the action you want to perform:</h2>
@@ -341,23 +414,45 @@
 </section>
 <section id="section-upload">
 	<h2>2. Upload the file</h2>
-	<form id="form-file" method="post" enctype="multipart/form-data">
-		<i id="icon-upload" class="icon fa fa-upload fa-2x"></i>
-		<input type="button" id="button-file" value="Upload a file!">
-		<input type="file" id="file" name="documentContent" value="">
-		<input type="hidden" name="sourceLocale" value="en-US">
-		<input type="hidden" name="targetLocale" value="it-IT">
-	</form>
-	<div id="file-details">Uploaded!</div>
+    <form id="form-file" method="post" enctype="multipart/form-data">
+        <ul>
+            <li>
+                <i id="icon-upload" class="icon fa fa-upload fa-2x"></i>
+                <input type="button" id="button-file" value="Upload a file!">
+                <input type="file" id="file" name="documentContent" value="">
+            </li>
+            <li class="locale">
+                <label for="src_lcl">Source locale </label>
+                <input type="text" id="src_lcl" name="sourceLocale" value="en-US">
+            </li>
+            <li class="locale">
+                <label for="tgt_lcl">Target locale </label>
+                <input type="text" id="tgt_lcl" name="targetLocale" value="it-IT">
+            </li>
+            <li>
+                <label for="dbg_mode">Retrieve logs </label>
+                <input type="checkbox" id="dbg_mode" name="debugMode" value="true">
+            </li>
+        </ul>
+    </form>
+    <div id="file-details">Uploaded!</div>
 </section>
 <section id="section-process">
-	<h2>3. Process and download</h2>
-	<div>
-		<i id="icon-process" class="icon fa fa-sign-out fa-2x"></i>
-		<img id="img-loading" src="https://i1.wp.com/cdnjs.cloudflare.com/ajax/libs/galleriffic/2.0.1/css/loader.gif">
-		<input type="button" id="button-process" value="Process"/>
-	</div>
-	<div><i id="icon-download" class="icon fa fa-download fa-2x"></i><input type="button" id="button-download" value="Download!" disabled/></div>
+    <h2>3. Process and download</h2>
+    <div>
+        <i id="icon-process" class="icon fa fa-sign-out fa-2x"></i>
+        <img id="img-loading" src="https://i1.wp.com/cdnjs.cloudflare.com/ajax/libs/galleriffic/2.0.1/css/loader.gif">
+        <input type="button" id="button-process" value="Process"/>
+    </div>
+    <div>
+        <i id="icon-download" class="icon fa fa-download fa-2x"></i>
+        <input type="button" id="button-download" value="Download!" disabled/>
+    </div>
+</section>
+<section id="section-log">
+    <div id="error">This is an error message!</div>
+    <h3>Logs</h3>
+    <textarea id="loglines" rows="15"></textarea>
 </section>
 </body>
 </html>

--- a/filters/src/main/resources/logback.xml
+++ b/filters/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date [%18thread] %5level | %40.40logger{40} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="net.sf.okapi" level="WARN"/>
+    <logger name="org.eclipse.jetty" level="WARN"/>
+    <root level="debug">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/filters/src/main/resources/simplelogger.properties
+++ b/filters/src/main/resources/simplelogger.properties
@@ -1,8 +1,0 @@
-org.slf4j.simpleLogger.logFile = System.out
-org.slf4j.simpleLogger.showLogName = false
-org.slf4j.simpleLogger.showShortLogName = true
-org.slf4j.simpleLogger.showDateTime = true
-org.slf4j.simpleLogger.dateTimeFormat = yyyy-MM-dd HH:mm:ss:SSS
-
-org.slf4j.simpleLogger.log.net.sf.okapi = WARN
-org.slf4j.simpleLogger.log.org.eclipse.jetty = WARN

--- a/filters/src/test/java/com/matecat/converter/server/resources/ConvertToXliffResourceTest.java
+++ b/filters/src/test/java/com/matecat/converter/server/resources/ConvertToXliffResourceTest.java
@@ -2,7 +2,6 @@ package com.matecat.converter.server.resources;
 
 import com.matecat.converter.server.JSONResponseFactory;
 import com.matecat.converter.server.MatecatConverterServer;
-import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
@@ -11,6 +10,7 @@ import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.entity.mime.content.StringBody;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.junit.After;
@@ -18,10 +18,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.ws.rs.Path;
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 
 import static org.junit.Assert.*;
 
@@ -31,52 +29,82 @@ public class ConvertToXliffResourceTest {
     private static MatecatConverterServer server;
     private static final int PORT = 8090;
     private static final String url = "http://localhost:" + PORT + ConvertToXliffResource.class.getAnnotation(Path.class).value();
+    private static final File fileToUpload = new File(ConvertToXliffResourceTest.class.getResource("/server/test.docx").getPath());
 
     @Before
     public void setUp() throws Exception {
         server = new MatecatConverterServer(PORT);
-        while ( !server.isStarted() )
+        while (!server.isStarted())
             Thread.sleep(100);
+    }
+
+    private MultipartEntityBuilder prepareMultipartBuilder() {
+        MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+        FileBody uploadFilePart = new FileBody(fileToUpload);
+        builder.addPart("documentContent", uploadFilePart);
+        builder.addPart("sourceLocale", new StringBody("en-US", ContentType.TEXT_PLAIN));
+        builder.addPart("targetLocale", new StringBody("fr-FR", ContentType.TEXT_PLAIN));
+        return builder;
     }
 
     @Test
     public void testConvertSuccess() throws Exception {
-
-        File fileToUpload = new File(getClass().getResource("/server/test.docx").getPath());
-
         // Send request
-        HttpClient httpclient = HttpClientBuilder.create().build();
         HttpPost httpPost = new HttpPost(url);
-        FileBody uploadFilePart = new FileBody(fileToUpload);
-        MultipartEntityBuilder reqEntity = MultipartEntityBuilder.create();
-        reqEntity.addPart("documentContent", uploadFilePart);
-        reqEntity.addPart("sourceLocale", new StringBody("en-US", ContentType.TEXT_PLAIN));
-        reqEntity.addPart("targetLocale", new StringBody("fr-FR", ContentType.TEXT_PLAIN));
-        httpPost.setEntity(reqEntity.build());
+        httpPost.setEntity(prepareMultipartBuilder().build());
+        HttpClient httpclient = HttpClientBuilder.create().build();
         HttpResponse response = httpclient.execute(httpPost);
-
         // Check OK status code
         assertEquals(200, response.getStatusLine().getStatusCode());
-
-        // Check body
-        String body = new BufferedReader(new InputStreamReader(response.getEntity().getContent())).readLine();
-        JSONObject json = (JSONObject) new JSONParser().parse(body);
-
+        // Parse body as JSON
+        final InputStreamReader reader = new InputStreamReader(response.getEntity().getContent());
+        JSONObject json = (JSONObject) new JSONParser().parse(reader);
         // Is success
         boolean isSuccess = (boolean) json.get(JSONResponseFactory.IS_SUCCESS);
         assertTrue(isSuccess);
-
         // No error message
         String error = (String) json.getOrDefault(JSONResponseFactory.ERROR_MESSAGE, "");
         assertEquals("", error);
-
+        // filename
+        final String name = (String) json.get(JSONResponseFactory.FILENAME);
+        assertNotNull(name);
+        assertEquals(fileToUpload.getName() + ".xlf", name);
         // Encoded document
         String doc = (String) json.get(JSONResponseFactory.XLIFF_CONTENT);
         assertNotSame("", doc);
+    }
 
-        File out = new File(fileToUpload.getPath() + ".xlf");
-        FileUtils.writeStringToFile(out, doc, Charset.forName("UTF-8"));
-
+    @Test
+    public void testConvertDebug() throws Exception {
+        // Send request
+        HttpPost httpPost = new HttpPost(url);
+        final MultipartEntityBuilder builder = prepareMultipartBuilder();
+        builder.addPart("debugMode", new StringBody("true", ContentType.TEXT_PLAIN));
+        httpPost.setEntity(builder.build());
+        HttpClient httpclient = HttpClientBuilder.create().build();
+        HttpResponse response = httpclient.execute(httpPost);
+        // Check OK status code
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        // Parse body as JSON
+        final InputStreamReader reader = new InputStreamReader(response.getEntity().getContent());
+        JSONObject json = (JSONObject) new JSONParser().parse(reader);
+        // Is success
+        boolean isSuccess = (boolean) json.get(JSONResponseFactory.IS_SUCCESS);
+        assertTrue(isSuccess);
+        // No error message
+        String error = (String) json.getOrDefault(JSONResponseFactory.ERROR_MESSAGE, "");
+        assertEquals("", error);
+        // log
+        final JSONArray log = (JSONArray) json.get(JSONResponseFactory.DEBUG_LOG);
+        assertNotNull(log);
+        assertFalse(log.isEmpty());
+        // filename
+        final String name = (String) json.get(JSONResponseFactory.FILENAME);
+        assertNotNull(name);
+        assertEquals(fileToUpload.getName() + ".xlf", name);
+        // Encoded document
+        String doc = (String) json.get(JSONResponseFactory.XLIFF_CONTENT);
+        assertNotSame("", doc);
     }
 
     @After

--- a/filters/src/test/java/com/matecat/converter/server/resources/ExtractOriginalFileResourceTest.java
+++ b/filters/src/test/java/com/matecat/converter/server/resources/ExtractOriginalFileResourceTest.java
@@ -5,9 +5,12 @@ import com.matecat.converter.server.MatecatConverterServer;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.FileBody;
+import org.apache.http.entity.mime.content.StringBody;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.junit.After;
@@ -15,7 +18,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.ws.rs.Path;
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 
@@ -27,47 +29,80 @@ public class ExtractOriginalFileResourceTest {
     private static MatecatConverterServer server;
     private static final int PORT = 8090;
     private static final String url = "http://localhost:" + PORT + ExtractOriginalFileResource.class.getAnnotation(Path.class).value();
+    private static final File fileToUpload = new File(ExtractOriginalFileResourceTest.class.getResource("/server/test.docx.xlf").getPath());
 
     @Before
     public void setUp() throws Exception {
         server = new MatecatConverterServer(PORT);
-        while ( !server.isStarted() )
+        while (!server.isStarted())
             Thread.sleep(100);
+    }
+
+    private MultipartEntityBuilder prepareMultipartBuilder() {
+        MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+        FileBody uploadFilePart = new FileBody(fileToUpload);
+        builder.addPart("file", uploadFilePart);
+        return builder;
     }
 
     @Test
     public void testOriginalSuccess() throws Exception {
-
-        File fileToUpload = new File(getClass().getResource("/server/test.docx.xlf").getPath());
-
         // Send request
-        HttpClient httpclient = HttpClientBuilder.create().build();
         HttpPost httpPost = new HttpPost(url);
-        FileBody uploadFilePart = new FileBody(fileToUpload);
-        MultipartEntityBuilder reqEntity = MultipartEntityBuilder.create();
-        reqEntity.addPart("file", uploadFilePart);
-        httpPost.setEntity(reqEntity.build());
+        httpPost.setEntity(prepareMultipartBuilder().build());
+        HttpClient httpclient = HttpClientBuilder.create().build();
         HttpResponse response = httpclient.execute(httpPost);
-
         // Check OK status code
         assertEquals(200, response.getStatusLine().getStatusCode());
-
-        // Check body
-        String body = new BufferedReader(new InputStreamReader(response.getEntity().getContent())).readLine();
-        JSONObject json = (JSONObject) new JSONParser().parse(body);
-
+        // Parse body as JSON
+        final InputStreamReader reader = new InputStreamReader(response.getEntity().getContent());
+        JSONObject json = (JSONObject) new JSONParser().parse(reader);
         // Is success
         boolean isSuccess = (boolean) json.get(JSONResponseFactory.IS_SUCCESS);
         assertTrue(isSuccess);
-
         // No error message
         String error = (String) json.getOrDefault(JSONResponseFactory.ERROR_MESSAGE, "");
         assertEquals("", error);
-
+        // filename
+        final String name = (String) json.get(JSONResponseFactory.FILENAME);
+        assertNotNull(name);
+        assertEquals(fileToUpload.getName().replaceAll(".xlf", ""), name);
         // Encoded document
         String encodedDoc = (String) json.get(JSONResponseFactory.DOCUMENT_CONTENT);
         assertNotSame("", encodedDoc);
+    }
 
+    @Test
+    public void testOriginalDebug() throws Exception {
+        // Send request
+        HttpPost httpPost = new HttpPost(url);
+        final MultipartEntityBuilder builder = prepareMultipartBuilder();
+        builder.addPart("debugMode", new StringBody("true", ContentType.TEXT_PLAIN));
+        httpPost.setEntity(builder.build());
+        HttpClient httpclient = HttpClientBuilder.create().build();
+        HttpResponse response = httpclient.execute(httpPost);
+        // Check OK status code
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        // Parse body as JSON
+        final InputStreamReader reader = new InputStreamReader(response.getEntity().getContent());
+        JSONObject json = (JSONObject) new JSONParser().parse(reader);
+        // Is success
+        boolean isSuccess = (boolean) json.get(JSONResponseFactory.IS_SUCCESS);
+        assertTrue(isSuccess);
+        // No error message
+        String error = (String) json.getOrDefault(JSONResponseFactory.ERROR_MESSAGE, "");
+        assertEquals("", error);
+        // log
+        final JSONArray log = (JSONArray) json.get(JSONResponseFactory.DEBUG_LOG);
+        assertNotNull(log);
+        assertFalse(log.isEmpty());
+        // filename
+        final String name = (String) json.get(JSONResponseFactory.FILENAME);
+        assertNotNull(name);
+        assertNotEquals("", name);
+        // Encoded document
+        String doc = (String) json.get(JSONResponseFactory.DOCUMENT_CONTENT);
+        assertNotSame("", doc);
     }
 
     @After

--- a/filters/src/test/java/com/matecat/converter/server/resources/GenerateDerivedFileResourceTest.java
+++ b/filters/src/test/java/com/matecat/converter/server/resources/GenerateDerivedFileResourceTest.java
@@ -5,9 +5,12 @@ import com.matecat.converter.server.MatecatConverterServer;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.FileBody;
+import org.apache.http.entity.mime.content.StringBody;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.junit.After;
@@ -15,7 +18,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.ws.rs.Path;
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 
@@ -27,47 +29,80 @@ public class GenerateDerivedFileResourceTest {
     private static MatecatConverterServer server;
     private static final int PORT = 8090;
     private static final String url = "http://localhost:" + PORT + GenerateDerivedFileResource.class.getAnnotation(Path.class).value();
+    private static final File fileToUpload = new File(GenerateDerivedFileResourceTest.class.getResource("/server/test.docx.xlf").getPath());
 
     @Before
     public void setUp() throws Exception {
         server = new MatecatConverterServer(PORT);
-        while ( !server.isStarted() )
+        while (!server.isStarted())
             Thread.sleep(100);
+    }
+
+    private MultipartEntityBuilder prepareMultipartBuilder() {
+        MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+        FileBody uploadFilePart = new FileBody(fileToUpload);
+        builder.addPart("xliffContent", uploadFilePart);
+        return builder;
     }
 
     @Test
     public void testDeriveSuccess() throws Exception {
-
-        File fileToUpload = new File(getClass().getResource("/server/test.docx.xlf").getPath());
-
         // Send request
-        HttpClient httpclient = HttpClientBuilder.create().build();
         HttpPost httpPost = new HttpPost(url);
-        FileBody uploadFilePart = new FileBody(fileToUpload);
-        MultipartEntityBuilder reqEntity = MultipartEntityBuilder.create();
-        reqEntity.addPart("xliffContent", uploadFilePart);
-        httpPost.setEntity(reqEntity.build());
+        httpPost.setEntity(prepareMultipartBuilder().build());
+        HttpClient httpclient = HttpClientBuilder.create().build();
         HttpResponse response = httpclient.execute(httpPost);
-
         // Check OK status code
         assertEquals(200, response.getStatusLine().getStatusCode());
-
-        // Check body
-        String body = new BufferedReader(new InputStreamReader(response.getEntity().getContent())).readLine();
-        JSONObject json = (JSONObject) new JSONParser().parse(body);
-
+        // Parse body as JSON
+        final InputStreamReader reader = new InputStreamReader(response.getEntity().getContent());
+        JSONObject json = (JSONObject) new JSONParser().parse(reader);
         // Is success
         boolean isSuccess = (boolean) json.get(JSONResponseFactory.IS_SUCCESS);
         assertTrue(isSuccess);
-
         // No error message
         String error = (String) json.getOrDefault(JSONResponseFactory.ERROR_MESSAGE, "");
         assertEquals("", error);
-
+        // filename
+        final String name = (String) json.get(JSONResponseFactory.FILENAME);
+        assertNotNull(name);
+        assertEquals(fileToUpload.getName().replaceAll(".docx.xlf", ".out.docx"), name);
         // Encoded document
         String encodedDoc = (String) json.get(JSONResponseFactory.DOCUMENT_CONTENT);
         assertNotSame("", encodedDoc);
+    }
 
+    @Test
+    public void testDeriveDebug() throws Exception {
+        // Send request
+        HttpPost httpPost = new HttpPost(url);
+        final MultipartEntityBuilder builder = prepareMultipartBuilder();
+        builder.addPart("debugMode", new StringBody("true", ContentType.TEXT_PLAIN));
+        httpPost.setEntity(builder.build());
+        HttpClient httpclient = HttpClientBuilder.create().build();
+        HttpResponse response = httpclient.execute(httpPost);
+        // Check OK status code
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        // Parse body as JSON
+        final InputStreamReader reader = new InputStreamReader(response.getEntity().getContent());
+        JSONObject json = (JSONObject) new JSONParser().parse(reader);
+        // Is success
+        boolean isSuccess = (boolean) json.get(JSONResponseFactory.IS_SUCCESS);
+        assertTrue(isSuccess);
+        // No error message
+        String error = (String) json.getOrDefault(JSONResponseFactory.ERROR_MESSAGE, "");
+        assertEquals("", error);
+        // log
+        final JSONArray log = (JSONArray) json.get(JSONResponseFactory.DEBUG_LOG);
+        assertNotNull(log);
+        assertFalse(log.isEmpty());
+        // filename
+        final String name = (String) json.get(JSONResponseFactory.FILENAME);
+        assertNotNull(name);
+        assertNotEquals("", name);
+        // Encoded document
+        String doc = (String) json.get(JSONResponseFactory.DOCUMENT_CONTENT);
+        assertNotSame("", doc);
     }
 
     @After


### PR DESCRIPTION
When debugMode POST parameter is set to true (default false) a
custom appender is temporarily added to the root logger to
capture all the log events raised while serving the request.
The resulting capture is then returned in a JSON field of the response.

Changed the logging library from slf4j-simple to logback.

The factory of the JSON responses now writes the field in a fixed order.

Added unit tests of the feature.

Modified the web interface to ask for debug mode and show resulting
logs.