### PR TITLE
Upgraded jetty to 9.4.28

### DIFF
--- a/filters/pom.xml
+++ b/filters/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <jetty.version>9.4.14.v20181114</jetty.version>
+        <jetty.version>9.4.28.v20200408</jetty.version>
         <jersey.version>2.28</jersey.version>
         <okapi.version>0.36</okapi.version>
         <!--


### PR DESCRIPTION
This should deal with vulnerabilities discovered in Jetty and affecting the previous version.