### PR TITLE
Added request tracing and Sentry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 ## Unreleased
 
-* Added debug mode: by setting `debugMode` POST parameter to `true` the JSON response will include the logs captured while serving the request.
+* Introduced initial use of Sentry (http://sentry.io) for problem capturing.
+* Added request tracing to a dedicated logger.
 * Revisited WinConverter configuration: no more Consul and simplified definition of WinConverter instances (this was a Translated internal development).
+* Added debug mode: by setting `debugMode` POST parameter to `true` the JSON response will include the logs captured while serving the request.
+* Upgraded Jetty to 9.4.28
 
 
 

--- a/filters/pom.xml
+++ b/filters/pom.xml
@@ -74,6 +74,16 @@
             <artifactId>logback-classic</artifactId>
             <version>1.2.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry</artifactId>
+            <version>1.7.30</version>
+        </dependency>
 
         <!-- JETTY -->
         <dependency>

--- a/filters/src/main/java/com/matecat/converter/Main.java
+++ b/filters/src/main/java/com/matecat/converter/Main.java
@@ -1,6 +1,8 @@
 package com.matecat.converter;
 
+import ch.qos.logback.classic.LoggerContext;
 import com.matecat.converter.server.MatecatConverterServer;
+import io.sentry.Sentry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,19 +15,25 @@ public class Main {
 
 
 	public static void main(String[] args) throws Exception {
-		if (Charset.defaultCharset() != StandardCharsets.UTF_8) {
-			throw new Exception("Java default charset is " + Charset.defaultCharset() + ", must be UTF-8. Fix your configuration.");
-		}
+        Sentry.init();
 
-		// Init the server
-		MatecatConverterServer server = new MatecatConverterServer();
+        if (Charset.defaultCharset() != StandardCharsets.UTF_8) {
+            throw new Exception("Java default charset is " + Charset.defaultCharset() + ", must be UTF-8. Fix your configuration.");
+        }
 
-		// Shutdown gracefully when receiving SIGTERM or similar
-		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-			LOGGER.info("Shutdown signal received, stopping the server...");
-			server.stop();
-			LOGGER.info("Server stopped successfully. Good bye!");
-		}));
+        // Init the server
+        MatecatConverterServer server = new MatecatConverterServer();
+
+        // Shutdown gracefully when receiving SIGTERM or similar
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            LOGGER.info("Shutdown signal received, stopping the server...");
+            server.stop();
+            Sentry.close();
+            LOGGER.info("Server stopped successfully. Good bye!");
+            // clean stopping of the logging library
+            LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+            loggerContext.stop();
+        }));
 	}
 
 }

--- a/filters/src/main/java/com/matecat/converter/server/resources/BaseResource.java
+++ b/filters/src/main/java/com/matecat/converter/server/resources/BaseResource.java
@@ -1,0 +1,120 @@
+package com.matecat.converter.server.resources;
+
+import com.matecat.converter.core.project.Project;
+import com.matecat.logging.StoringAppender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Base class for REST Resources.
+ * <p>
+ * Deals mainly with request tracing and common logic.
+ */
+public class BaseResource {
+    protected static final StoringAppender LOG_CAPTURER = new StoringAppender();
+    protected static final Logger TRACER = LoggerFactory.getLogger("req-tracing");
+    protected static final String CACHE_ID = "cacheId";
+    protected static final String ELAPSED = "elapsed";
+    protected static final String FILENAME = "fileName";
+    protected static final String FILESIZE = "fileSize";
+    protected static final String OPERATION = "operation";
+    protected static final String REQ_ID = "reqId";
+    protected static final String SOURCE_FILENAME = "sourceFileName";
+    protected static final String SOURCE_FILESIZE = "sourceFileSize";
+    protected static final String SRC_LANG = "sourceLanguage";
+    protected static final String SUCCESSFUL = "successful";
+    protected static final String TARGET_FILENAME = "targetFileName";
+    protected static final String TARGET_FILESIZE = "targetFileSize";
+    protected static final String TGT_LANG = "targetLanguage";
+    protected static final String TIMESTAMP = "timestamp";
+
+
+    /**
+     * Enumeration for filters operation types.
+     */
+    protected enum Operations {
+        SOURCE2XLIFF, XLIFF2SOURCE, XLIFF2TARGET;
+    }
+
+    /**
+     * Builds a random request id with the pattern HHMM-################# where
+     * HH = hour, MM = minutes and # = a random alphanumeric character.
+     *
+     * @return The generated id
+     */
+    protected String generateRequestId() {
+        final ThreadLocalRandom rand = ThreadLocalRandom.current();
+        return String.format("%1$tH%1$tM-%2$xd", new Date(), rand.nextLong());
+    }
+
+    /**
+     * Trace start of a request.
+     *
+     * @param operation the operation type of the request
+     */
+    protected void traceStart(Operations operation) {
+        // TODO: take the req id from an HTTP header if possible (filter proxy)
+        MDC.put(REQ_ID, generateRequestId());
+        MDC.put(OPERATION, operation.toString());
+        MDC.put(TIMESTAMP, Instant.now().toString());
+        // TODO: put the IP address of the request in the context
+        TRACER.debug("Request start");
+    }
+
+    /**
+     * Trace end of a request.
+     */
+    protected void traceEnd() {
+        final Duration elapsed = Duration.between(Instant.parse(MDC.get(TIMESTAMP)), Instant.now());
+        MDC.put(ELAPSED, elapsed.toString());
+        if (Boolean.parseBoolean(MDC.get(SUCCESSFUL))) {
+            TRACER.info("Request served");
+        } else {
+            TRACER.error("Request failed");
+        }
+    }
+
+    /**
+     * If debug mode requested install the log capturer.
+     *
+     * @param debugEnabled true to enable debug mode
+     */
+    protected void setupDebugMode(boolean debugEnabled) {
+        if (debugEnabled) {
+            LOG_CAPTURER.install();
+        }
+    }
+
+    /**
+     * Perform cleanup actions at the end of a request.
+     *
+     * @param fileInputStream file input stream to close
+     * @param debugMode       true if debug mode cleanup requested
+     * @param project         project to delete (depending on configuration and outcome)
+     * @param reqOutcome      true if request successful
+     */
+    protected void requestCleanup(InputStream fileInputStream, boolean debugMode, Project project, boolean reqOutcome) {
+        // Close the file stream
+        if (fileInputStream != null)
+            try {
+                fileInputStream.close();
+            } catch (IOException ignored) {
+            }
+        // Delete folder only if everything went well
+        if (project != null)
+            project.close(reqOutcome);
+        // If debug mode requested de-install the log capturer
+        if (debugMode) {
+            LOG_CAPTURER.clear();
+            LOG_CAPTURER.deinstall();
+        }
+    }
+}

--- a/filters/src/main/java/com/matecat/converter/server/resources/ConvertToXliffResource.java
+++ b/filters/src/main/java/com/matecat/converter/server/resources/ConvertToXliffResource.java
@@ -5,7 +5,7 @@ import com.matecat.converter.core.project.ProjectFactory;
 import com.matecat.converter.server.JSONResponseFactory;
 import com.matecat.converter.server.exceptions.ServerException;
 import com.matecat.filters.basefilters.FiltersRouter;
-import com.matecat.logging.StoringAppender;
+import io.sentry.Sentry;
 import net.sf.okapi.common.exceptions.OkapiEncryptedDataException;
 import net.sf.okapi.common.exceptions.OkapiUnexpectedRevisionException;
 import org.apache.commons.io.FilenameUtils;
@@ -13,24 +13,24 @@ import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Locale;
 import java.util.MissingResourceException;
+
 
 /**
  * Resource taking care of the conversion task into .XLF
  */
 @Path("/AutomationService/original2xliff")
-public class ConvertToXliffResource {
+public class ConvertToXliffResource extends BaseResource {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConvertToXliffResource.class);
-    private static final StoringAppender LOG_CAPTURER = new StoringAppender();
 
     /**
      * Convert a file into XLF
@@ -46,94 +46,92 @@ public class ConvertToXliffResource {
             @FormDataParam("targetLocale") String targetLanguageCode,
             @FormDataParam("segmentation") String segmentation,
             @FormDataParam("debugMode") @DefaultValue("false") boolean debugMode) {
-        // If debug mode requested install the log capturer
-        if (debugMode) {
-            LOG_CAPTURER.install();
-        }
-
-        // Due to a bug in the MIMEPull library (MIMEParser.java line 510),
-        // contentDispositionHeader.getFileName() returns the filename in ISO-8859-1
-        // even if it was sent in UTF-8. Unless this bug is there, here is a little
-        // workaround: you can send the filename in UTF-8 in the 'fileName' POST
-        // param. If the 'fileName' parameter is present, it overrides the name of
-        // the file in 'documentContent'
-        if (filename == null || filename.isEmpty())
-            filename = FilenameUtils.getName(contentDispositionHeader.getFileName());
-
-        // Make extension ALWAYS lower case.
-        // The original extension of the file is written in the output XLIFF
-        // always lowercase, for compliance with the XLIFF spec (see datatype
-        // attribute of <file> element). This causes insidious bugs in the
-        // back-conversion, very difficult to solve with the current class
-        // structure (I tried). This fixes it easily.
-        // TODO: refactor internal classes to be filename/extension agnostic
-        filename = FilenameUtils.removeExtension(filename) + "." + FilenameUtils.getExtension(filename).toLowerCase();
-
-        LOGGER.info("SOURCE > XLIFF request: file=<{}> source=<{}> target=<{}>", filename, sourceLanguageCode, targetLanguageCode);
-
-        Project project = null;
-        File xlf = new File("");
-        String errorMessage = "Unknown error";
-        Response response;
-        boolean everythingOk = false;
+        traceStart(Operations.SOURCE2XLIFF);
         try {
-            // Check that the input file is not null
-            if (fileInputStream == null) {
-                throw new IllegalArgumentException("The input file has not been sent");
-            }
+            // If debug mode requested install the log capturer
+            setupDebugMode(debugMode);
 
-            // Parse the codes
-            Locale sourceLanguage = parseLanguage(sourceLanguageCode);
-            Locale targetLanguage = parseLanguage(targetLanguageCode);
+            // Due to a bug in the MIMEPull library (MIMEParser.java line 510),
+            // contentDispositionHeader.getFileName() returns the filename in ISO-8859-1
+            // even if it was sent in UTF-8. Unless this bug is there, here is a little
+            // workaround: you can send the filename in UTF-8 in the 'fileName' POST
+            // param. If the 'fileName' parameter is present, it overrides the name of
+            // the file in 'documentContent'
+            if (filename == null || filename.isEmpty())
+                filename = FilenameUtils.getName(contentDispositionHeader.getFileName());
 
-            // Create the project
-            project = ProjectFactory.createProject(filename, fileInputStream);
+            // Make extension ALWAYS lower case.
+            // The original extension of the file is written in the output XLIFF
+            // always lowercase, for compliance with the XLIFF spec (see datatype
+            // attribute of <file> element). This causes insidious bugs in the
+            // back-conversion, very difficult to solve with the current class
+            // structure (I tried). This fixes it easily.
+            // TODO: refactor internal classes to be filename/extension agnostic
+            filename = FilenameUtils.removeExtension(filename) + "." + FilenameUtils.getExtension(filename).toLowerCase();
 
-            // Retrieve the xlf
-            xlf = new FiltersRouter().extract(project.getFile(), sourceLanguage, targetLanguage, segmentation);
+            LOGGER.info("SOURCE > XLIFF request: file=<{}> source=<{}> target=<{}>", filename, sourceLanguageCode, targetLanguageCode);
+            MDC.put(FILENAME, filename);
+            MDC.put(SRC_LANG, sourceLanguageCode);
+            MDC.put(TGT_LANG, targetLanguageCode);
 
-            // Set OK flag
-            everythingOk = true;
-            LOGGER.info("Successfully returned XLIFF file");
-        } catch (Exception e) {
-            // If there is any error, return it
-            if (e instanceof OkapiUnexpectedRevisionException) {
-                errorMessage = "Document contains revisions or comments, please review and remove them.";
-            } else if (e instanceof OkapiEncryptedDataException) {
-                errorMessage = "Document is password protected: can't access to contents.";
-            } else {
-                errorMessage = e.toString();
-            }
-            LOGGER.error("Exception converting source to XLIFF", e);
-        } finally {
-            // Create response
-            if (everythingOk) {
-                response = Response
-                        .status(Response.Status.OK)
-                        .entity(JSONResponseFactory.getConvertSuccess(xlf, LOG_CAPTURER.getStoredLog()))
-                        .build();
-            } else {
-                response = Response
-                        .status(Response.Status.BAD_REQUEST)
-                        .entity(JSONResponseFactory.getError(errorMessage, LOG_CAPTURER.getStoredLog()))
-                        .build();
-            }
-            // Close the project and streams
-            if (fileInputStream != null)
-                try {
-                    fileInputStream.close();
-                } catch (IOException ignored) {
+            Project project = null;
+            File xlf = new File("");
+            String errorMessage = "Unknown error";
+            Response response;
+            boolean everythingOk = false;
+            try {
+                // Check that the input file is not null
+                if (fileInputStream == null) {
+                    throw new IllegalArgumentException("The input file has not been sent");
                 }
-            // Delete folder only if everything went well
-            if (project != null)
-                project.close(everythingOk);
-            // If debug mode requested de-install the log capturer
-            if (debugMode) {
-                LOG_CAPTURER.clear();
-                LOG_CAPTURER.deinstall();
+
+                // Parse the codes
+                Locale sourceLanguage = parseLanguage(sourceLanguageCode);
+                Locale targetLanguage = parseLanguage(targetLanguageCode);
+
+                // Create the project
+                project = ProjectFactory.createProject(filename, fileInputStream);
+                MDC.put(CACHE_ID, project.getFolder().getName());
+                MDC.put(FILESIZE, String.valueOf(project.getFile().length()));
+
+                // Retrieve the xlf
+                xlf = new FiltersRouter().extract(project.getFile(), sourceLanguage, targetLanguage, segmentation);
+
+                // Set OK flag
+                everythingOk = true;
+                MDC.put(SUCCESSFUL, String.valueOf(true));
+                LOGGER.info("Successfully returned XLIFF file");
+            } catch (Exception e) {
+                Sentry.capture(e);
+                // If there is any error, return it
+                if (e instanceof OkapiUnexpectedRevisionException) {
+                    errorMessage = "Document contains revisions or comments, please review and remove them.";
+                } else if (e instanceof OkapiEncryptedDataException) {
+                    errorMessage = "Document is password protected: can't access contents.";
+                } else {
+                    errorMessage = e.toString();
+                }
+                LOGGER.error("Exception converting source to XLIFF", e);
+            } finally {
+                // Create response
+                if (everythingOk) {
+                    response = Response
+                            .status(Response.Status.OK)
+                            .entity(JSONResponseFactory.getConvertSuccess(xlf, LOG_CAPTURER.getStoredLog()))
+                            .build();
+                } else {
+                    response = Response
+                            .status(Response.Status.BAD_REQUEST)
+                            .entity(JSONResponseFactory.getError(errorMessage, LOG_CAPTURER.getStoredLog()))
+                            .build();
+                }
+                // Close the project and streams
+                requestCleanup(fileInputStream, debugMode, project, everythingOk);
             }
+            return response;
+        } finally {
+            traceEnd();
         }
-        return response;
     }
 
     /**

--- a/filters/src/main/java/com/matecat/converter/server/resources/ExtractOriginalFileResource.java
+++ b/filters/src/main/java/com/matecat/converter/server/resources/ExtractOriginalFileResource.java
@@ -4,26 +4,26 @@ import com.matecat.converter.core.XliffProcessor;
 import com.matecat.converter.core.project.Project;
 import com.matecat.converter.core.project.ProjectFactory;
 import com.matecat.converter.server.JSONResponseFactory;
-import com.matecat.logging.StoringAppender;
+import io.sentry.Sentry;
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 
 /**
  * Resource taking care of the extraction of the original file from the .XLF
  */
 @Path("/AutomationService/xliff2source")
-public class ExtractOriginalFileResource {
+public class ExtractOriginalFileResource extends BaseResource {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConvertToXliffResource.class);
-    private static final StoringAppender LOG_CAPTURER = new StoringAppender();
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExtractOriginalFileResource.class);
 
     /**
      * Extract the original file from the xlf
@@ -33,67 +33,66 @@ public class ExtractOriginalFileResource {
     @Produces("application/json")
     public Response convert(
             @FormDataParam("file") InputStream fileInputStream,
+            @FormDataParam("file") FormDataContentDisposition contentDispositionHeader,
             @FormDataParam("debugMode") @DefaultValue("false") boolean debugMode) {
-        // If debug mode requested install the log capturer
-        if (debugMode) {
-            LOG_CAPTURER.install();
-        }
-
-        LOGGER.info("XLIFF > SOURCE request");
-
-        Project project = null;
-        File originalFile = new File("");
-        String errorMessage = "Unknown error";
-        Response response;
-        boolean everythingOk = false;
+        traceStart(Operations.XLIFF2SOURCE);
         try {
-            // Check that the input file is not null
-            if (fileInputStream == null) {
-                throw new IllegalArgumentException("The input file has not been sent");
-            }
+            // If debug mode requested install the log capturer
+            setupDebugMode(debugMode);
 
-            // Create the project
-            project = ProjectFactory.createProject("to-original.xlf", fileInputStream);
+            LOGGER.info("XLIFF > SOURCE request");
+            MDC.put(FILENAME, contentDispositionHeader.getFileName());
 
-            // Retrieve the xlf
-            originalFile = new XliffProcessor(project.getFile()).getOriginalFile();
-
-            // Set OK flag
-            everythingOk = true;
-            LOGGER.info("Successfully returned source file");
-        } catch (Exception e) {
-            // Save error message
-            errorMessage = e.toString();
-            LOGGER.error("Exception converting XLIFF to source", e);
-        } finally {
-            // Create response
-            if (everythingOk) {
-                response = Response
-                        .status(Response.Status.OK)
-                        .entity(JSONResponseFactory.getDerivedSuccess(originalFile, LOG_CAPTURER.getStoredLog()))
-                        .build();
-            } else {
-                response = Response
-                        .status(Response.Status.BAD_REQUEST)
-                        .entity(JSONResponseFactory.getError(errorMessage, LOG_CAPTURER.getStoredLog()))
-                        .build();
-            }
-            // Close the project and streams
-            if (fileInputStream != null)
-                try {
-                    fileInputStream.close();
-                } catch (IOException ignored) {
+            Project project = null;
+            File originalFile = new File("");
+            String errorMessage = "Unknown error";
+            Response response;
+            boolean everythingOk = false;
+            try {
+                // Check that the input file is not null
+                if (fileInputStream == null) {
+                    throw new IllegalArgumentException("The input file has not been sent");
                 }
-            if (project != null)
-                // Delete folder only if everything went well
-                project.close(everythingOk);
-            // If debug mode requested de-install the log capturer
-            if (debugMode) {
-                LOG_CAPTURER.clear();
-                LOG_CAPTURER.deinstall();
+
+                // Create the project
+                project = ProjectFactory.createProject("to-original.xlf", fileInputStream);
+                MDC.put(CACHE_ID, project.getFolder().getName());
+                MDC.put(FILESIZE, String.valueOf(project.getFile().length()));
+
+                // Retrieve the xlf
+                originalFile = new XliffProcessor(project.getFile()).getOriginalFile();
+                MDC.put(SOURCE_FILENAME, originalFile.getName());
+                MDC.put(SOURCE_FILESIZE, String.valueOf(originalFile.length()));
+
+                // Set OK flag
+                everythingOk = true;
+                MDC.put(SUCCESSFUL, String.valueOf(true));
+                LOGGER.info("Successfully returned source file");
+            } catch (Exception e) {
+                Sentry.capture(e);
+                // Save error message
+                errorMessage = e.toString();
+                LOGGER.error("Exception converting XLIFF to source", e);
+            } finally {
+                // Create response
+                if (everythingOk) {
+                    response = Response
+                            .status(Response.Status.OK)
+                            .entity(JSONResponseFactory.getDerivedSuccess(originalFile, LOG_CAPTURER.getStoredLog()))
+                            .build();
+                } else {
+                    response = Response
+                            .status(Response.Status.BAD_REQUEST)
+                            .entity(JSONResponseFactory.getError(errorMessage, LOG_CAPTURER.getStoredLog()))
+                            .build();
+                }
+                // Close the project and streams
+                requestCleanup(fileInputStream, debugMode, project, everythingOk);
             }
+            return response;
+        } finally {
+            traceEnd();
         }
-        return response;
     }
 
 }

--- a/filters/src/main/java/com/matecat/converter/server/resources/GenerateDerivedFileResource.java
+++ b/filters/src/main/java/com/matecat/converter/server/resources/GenerateDerivedFileResource.java
@@ -4,26 +4,27 @@ import com.matecat.converter.core.project.Project;
 import com.matecat.converter.core.project.ProjectFactory;
 import com.matecat.converter.server.JSONResponseFactory;
 import com.matecat.filters.basefilters.FiltersRouter;
-import com.matecat.logging.StoringAppender;
+import io.sentry.Sentry;
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
+
 
 /**
  * Resource taking care of the generation of the new file from the .XLF
  */
 @Path("/AutomationService/xliff2original")
-public class GenerateDerivedFileResource {
+public class GenerateDerivedFileResource extends BaseResource {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConvertToXliffResource.class);
-    private static final StoringAppender LOG_CAPTURER = new StoringAppender();
+    private static final Logger LOGGER = LoggerFactory.getLogger(GenerateDerivedFileResource.class);
 
     /**
      * Generate the derived file from the xlf
@@ -33,65 +34,64 @@ public class GenerateDerivedFileResource {
     @Produces("application/json")
     public Response convert(
             @FormDataParam("xliffContent") InputStream fileInputStream,
+            @FormDataParam("xliffContent") FormDataContentDisposition contentDispositionHeader,
             @FormDataParam("debugMode") @DefaultValue("false") boolean debugMode) {
-        // If debug mode requested install the log capturer
-        if (debugMode) {
-            LOG_CAPTURER.install();
-        }
-
-        LOGGER.info("XLIFF > TARGET request");
-
-        Project project = null;
-        File derivedFile = new File("");
-        String errorMessage = "Unknown error";
-        Response response;
-        boolean everythingOk = false;
+        traceStart(Operations.XLIFF2TARGET);
         try {
-            // Check that the input file is not null
-            if (fileInputStream == null)
-                throw new IllegalArgumentException("The input file has not been sent");
+            // If debug mode requested install the log capturer
+            setupDebugMode(debugMode);
 
-            // Create the project
-            project = ProjectFactory.createProject("to-derived.xlf", fileInputStream);
+            LOGGER.info("XLIFF > TARGET request");
+            MDC.put(FILENAME, contentDispositionHeader.getFileName());
 
-            // Retrieve the xlf
-            derivedFile = new FiltersRouter().merge(project.getFile());
+            Project project = null;
+            File derivedFile = new File("");
+            String errorMessage = "Unknown error";
+            Response response;
+            boolean everythingOk = false;
+            try {
+                // Check that the input file is not null
+                if (fileInputStream == null)
+                    throw new IllegalArgumentException("The input file has not been sent");
 
-            everythingOk = true;
-            LOGGER.info("Successfully returned target file");
-        } catch (Exception e) {
-            // save error message
-            errorMessage = e.toString();
-            LOGGER.error("Exception converting XLIFF to target", e);
-        } finally {
-            // Create response
-            if (everythingOk) {
-                response = Response
-                        .status(Response.Status.OK)
-                        .entity(JSONResponseFactory.getDerivedSuccess(derivedFile, LOG_CAPTURER.getStoredLog()))
-                        .build();
-            } else {
-                response = Response
-                        .status(Response.Status.BAD_REQUEST)
-                        .entity(JSONResponseFactory.getError(errorMessage, LOG_CAPTURER.getStoredLog()))
-                        .build();
-            }
-            // Close the project and streams
-            if (fileInputStream != null)
-                try {
-                    fileInputStream.close();
-                } catch (IOException ignored) {
+                // Create the project
+                project = ProjectFactory.createProject("to-derived.xlf", fileInputStream);
+                MDC.put(CACHE_ID, project.getFolder().getName());
+                MDC.put(FILESIZE, String.valueOf(project.getFile().length()));
+
+                // Retrieve the xlf
+                derivedFile = new FiltersRouter().merge(project.getFile());
+                MDC.put(TARGET_FILENAME, derivedFile.getName());
+                MDC.put(TARGET_FILESIZE, String.valueOf(derivedFile.length()));
+
+                everythingOk = true;
+                MDC.put(SUCCESSFUL, String.valueOf(true));
+                LOGGER.info("Successfully returned target file");
+            } catch (Exception e) {
+                Sentry.capture(e);
+                // save error message
+                errorMessage = e.toString();
+                LOGGER.error("Exception converting XLIFF to target", e);
+            } finally {
+                // Create response
+                if (everythingOk) {
+                    response = Response
+                            .status(Response.Status.OK)
+                            .entity(JSONResponseFactory.getDerivedSuccess(derivedFile, LOG_CAPTURER.getStoredLog()))
+                            .build();
+                } else {
+                    response = Response
+                            .status(Response.Status.BAD_REQUEST)
+                            .entity(JSONResponseFactory.getError(errorMessage, LOG_CAPTURER.getStoredLog()))
+                            .build();
                 }
-            if (project != null)
-                // Delete folder only if everything went well
-                project.close(everythingOk);
-            // If debug mode requested de-install the log capturer
-            if (debugMode) {
-                LOG_CAPTURER.clear();
-                LOG_CAPTURER.deinstall();
+                // Close the project and streams
+                requestCleanup(fileInputStream, debugMode, project, everythingOk);
             }
+            return response;
+        } finally {
+            traceEnd();
         }
-        return response;
     }
 
 }

--- a/filters/src/main/java/com/matecat/logging/StoringAppender.java
+++ b/filters/src/main/java/com/matecat/logging/StoringAppender.java
@@ -85,6 +85,8 @@ public class StoringAppender extends AppenderBase<ILoggingEvent> {
         if (!consoleFound) {
             final PatternLayoutEncoder ple = new PatternLayoutEncoder();
             ple.setPattern(DEFAULT_PATTERN);
+            ple.setContext(lc);
+            ple.start();
             this.encoder = ple;
         }
         // start our self and add to root logger

--- a/filters/src/main/resources/logback.xml
+++ b/filters/src/main/resources/logback.xml
@@ -1,12 +1,24 @@
 <configuration>
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator"/>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
         <encoder>
             <pattern>%date [%18thread] %5level | %40.40logger{40} - %msg%n</pattern>
         </encoder>
     </appender>
-    <logger name="net.sf.okapi" level="WARN"/>
-    <logger name="org.eclipse.jetty" level="WARN"/>
-    <root level="debug">
+    <appender name="TRACEOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!--        <target>System.err</target>-->
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <pattern>%logger [%5level] %msg {%mdc}%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="req-tracing" level="debug" additivity="false">
+        <appender-ref ref="TRACEOUT"/>
+    </logger>
+    <logger name="net.sf.okapi" level="warn"/>
+    <logger name="org.eclipse.jetty" level="warn"/>
+    <root level="info">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/filters/src/main/resources/sentry.properties
+++ b/filters/src/main/resources/sentry.properties
@@ -1,0 +1,2 @@
+dsn=https://0d8a4d5435ed42eba580960ce660e8b4@o204823.ingest.sentry.io/5238754
+stacktrace.app.packages=com.matecat

--- a/http-requests/endpoints.http
+++ b/http-requests/endpoints.http
@@ -3,49 +3,49 @@ GET http://localhost:8732/test
 
 ###
 
-// Convert to XLIFF (ConvertToXliffResource.java)
-POST http://localhost:8732/AutomationService/original2xliff
-Content-Type: multipart/form-data; boundary=WebAppBoundary
+// Convert to XLIFF (ConvertToXliffResource.java)POST http://localhost:8732/AutomationService/original2xliff
+Content-Type: multipart/form-data; boundary=ReqBoundary
 
---WebAppBoundary
+--ReqBoundary
 Content-Disposition: form-data; name="fileName"
 
 cipperimerlo.csv
---WebAppBoundary
+--ReqBoundary
 Content-Disposition: form-data; name="sourceLocale"
 
 en-US
---WebAppBoundary
+--ReqBoundary
 Content-Disposition: form-data; name="targetLocale"
 
 it-IT
---WebAppBoundary
+--ReqBoundary
 Content-Disposition: form-data; name="documentContent"; filename="test.csv"
 
-< ./src/test/resources/okapi/test.csv
-#< ./src/test/resources/generation/test.docx
---WebAppBoundary--
+< ../filters/src/test/resources/okapi/test.csv
+#< ../filters/src/test/resources/generation/test.docx
+--ReqBoundary--
 
 ###
 
 // Extract target from XLIFF (GenerateDerivedFileResource.java)
 POST http://localhost:8732/AutomationService/xliff2original
-Content-Type: multipart/form-data; boundary=WebAppBoundary
+Content-Type: multipart/form-data; boundary=ReqBoundary
 
---WebAppBoundary
+--ReqBoundary
 Content-Disposition: form-data; name="xliffContent"; filename="test.docx.xlf"
 
-< ./src/test/resources/extraction/test.docx.xlf
---WebAppBoundary--
+< ../filters/src/test/resources/extraction/test.docx.xlf
+#< ../filters/src/test/resources/server/test.docx.xlf
+--ReqBoundary--
 
 ###
 
 // Extract source from XLIFF (ExtractOriginalFileResource.java)
 POST http://localhost:8732/AutomationService/xliff2source
-Content-Type: multipart/form-data; boundary=WebAppBoundary
+Content-Type: multipart/form-data; boundary=ReqBoundary
 
---WebAppBoundary
+--ReqBoundary
 Content-Disposition: form-data; name="file"; filename="test.docx.xlf"
 
-< ./src/test/resources/extraction/test.docx.xlf
---WebAppBoundary--
+< ../filters/src/test/resources/extraction/test.docx.xlf
+--ReqBoundary--


### PR DESCRIPTION
Extracted base resource class with common logic.
A try/finally enclosing logic allows to capture more problems and
correctly trace failing requests.
A specific appender for req-tracing log events is used in logback
configuration.

Introduced use of Sentry with sentry.properties config file.

Routed Jersey logging trough SLF4J adding java.util.logging redirector
dependency.

Fixed again resource classes logger
names.