### PR TITLE
Improved request tracing.

### DIFF
--- a/filters/pom.xml
+++ b/filters/pom.xml
@@ -69,6 +69,8 @@
             <artifactId>json</artifactId>
             <version>20170516</version>
         </dependency>
+
+        <!-- LOGGING-->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
@@ -78,6 +80,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
             <version>1.7.25</version>
+        </dependency>
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>6.3</version>
         </dependency>
 
         <!-- JETTY -->

--- a/filters/src/main/resources/logback.xml
+++ b/filters/src/main/resources/logback.xml
@@ -7,11 +7,8 @@
         </encoder>
     </appender>
     <appender name="TRACEOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <!--        <target>System.err</target>-->
         <immediateFlush>true</immediateFlush>
-        <encoder>
-            <pattern>%logger [%5level] %msg {%mdc}%n</pattern>
-        </encoder>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>
     <logger name="req-tracing" level="debug" additivity="false">
         <appender-ref ref="TRACEOUT"/>


### PR DESCRIPTION
Forgot to clear the MDC at each request.
Introduced LogstashEncoder to have log events formatted as JSON objects.
Added tracing of caller IP address.
The request id may now be taken from an HTTP header (will be put there by the filters proxy).